### PR TITLE
fix(gacha): 抽卡统计在go-cqhttp中无法正常使用

### DIFF
--- a/apps/Gacha.js
+++ b/apps/Gacha.js
@@ -33,6 +33,9 @@ export class Gacha extends plugin {
 
     async gachaCount(e) {
         let message = e.msg.replace(/^(～|~|鸣潮)(常驻(武器|角色)|限定(武器|角色))?抽卡(统计|分析|记录)/, "");
+        //适配go-cqhttp消息体，仅限抽卡bug
+        message = message.trim();
+        message = message.replaceAll("amp;", "");
 
         let jsonData = {};
 


### PR DESCRIPTION
1.message文本前有隐形字符，规范的文本格式使用startsWith方法返回false，使用trim方法去除后能正常进入判断分支
2.go-cqhttp返回的url中带有'amp;'转义，需要替换掉才能获取player_id和record_id